### PR TITLE
FIX PHP Fatal Error on an invalid Blip Field.

### DIFF
--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -1059,6 +1059,11 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
                             // picture
                             // get index to BSE entry (1-based)
                             $BSEindex = $spContainer->getOPT(0x0104);
+                            // If there is no BSE Index, we will fail here and other fields are not read. 
+                            // Fix by checking here. 
+                            // TODO: Why is there no BSE Index? Is this a new Office Version? Password protected field? 
+                            // More likely : a uncompatible picture
+                            if (!$BSEindex) { continue; }
                             $BSECollection = $escherWorkbook->getDggContainer()->getBstoreContainer()->getBSECollection();
                             $BSE = $BSECollection[$BSEindex - 1];
                             $blipType = $BSE->getBlipType();


### PR DESCRIPTION
For (still) unknown reasons, PHPExcel detects a wrong field type. 
If there is no BSE Index, we will fail here and other fields are not read. 
So if the BSE Index < 1, continue with the next field. 
TODO: Why is there no BSE Index? 
      Is this a new Office Version? 
      Password protected field? 
      More likely : a uncompatible picture

PHP Notice:  Undefined offset: -1 in Classes/PHPExcel/Reader/Excel5.php on line 1063
PHP Fatal error:  Call to a member function getBlipType() on a non-object in Classes/PHPExcel/Reader/Excel5.php on line 1064
